### PR TITLE
KprofilesSettingsFragment: Prevent an NPE

### DIFF
--- a/src/com/android/kprofiles/battery/KprofilesSettingsFragment.java
+++ b/src/com/android/kprofiles/battery/KprofilesSettingsFragment.java
@@ -152,6 +152,7 @@ public class KprofilesSettingsFragment extends PreferenceFragment implements
     }
 
     private String modesDesc(String mode) {
+        if (mode == null) mode = "0";
         String descrpition = null;
         if (!IS_SUPPORTED) return getString(R.string.kprofiles_not_supported);
         switch (mode) {


### PR DESCRIPTION
Log:
2023-03-12 21:18:46.474 18786 18786 system E AndroidRuntime : FATAL EXCEPTION: main Process: com.android.kprofiles, PID: 18786
java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.hashCode()' on a null object reference
 at com.android.kprofiles.battery.KprofilesSettingsFragment.modesDesc(KprofilesSettingsFragment.java:157)
 at com.android.kprofiles.battery.KprofilesSettingsFragment.lambda/bin/zsh(KprofilesSettingsFragment.java:181)
 at com.android.kprofiles.battery.KprofilesSettingsFragment.DYu9NgWWoqdIINe9b07l2lyB-g(Unknown Source:0)
 at com.android.kprofiles.battery.KprofilesSettingsFragment256765ExternalSyntheticLambda0.run(Unknown Source:4)
 at android.os.Handler.handleCallback(Handler.java:942)
 at android.os.Handler.dispatchMessage(Handler.java:99)
 at android.os.Looper.loopOnce(Looper.java:201)
 at android.os.Looper.loop(Looper.java:288)
 at android.app.ActivityThread.main(ActivityThread.java:7872)
 at java.lang.reflect.Method.invoke(Native Method)
 at com.android.internal.os.RuntimeInit.run(RuntimeInit.java:550)
 at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)